### PR TITLE
Fix omission of DOCTYPE in output

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -16,7 +16,7 @@ module.exports = (eleventyConfig, options = {}) => {
                     image.setAttribute('loading', 'lazy')
                 })
 
-                return document.documentElement.outerHTML
+                return dom.serialize()
             } else {
                 return content
             }


### PR DESCRIPTION
As mentioned here: https://github.com/jsdom/jsdom#serializing-the-document-with-serialize, using `document.documentElement.outerHTML` omits the `<!DOCTYPE html>`. This commit changes the code to use the `dom.serialize()` method so `<!DOCTYPE html>` is included in the output